### PR TITLE
Add examples in examples folder and explain in README.md

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "**" ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "**" ]
+    branches: [ "main" ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ target/
 .plan.md
 benchmark_plan.md
 crossover_analysis.md
+
+# Ignore IDEA / RustRover ide files
+.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,25 +122,22 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "3bf7af66b0989381bd0be551bd7cc91912a655a58c6918420c9527b1fd8b4679"
 dependencies = [
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
- "itertools",
+ "itertools 0.13.0",
  "num-traits 0.2.19",
- "once_cell",
  "oorandom",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -153,7 +150,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -268,27 +265,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
-
-[[package]]
-name = "is-terminal"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ default = []
 gpu = ["ocl"]
 
 [dev-dependencies]
-criterion = "0.5"
+criterion = "0.6.0"
 
 [[bench]]
 name = "quant_iron_benchmarks"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,9 @@ criterion = "0.6.0"
 name = "quant_iron_benchmarks"
 harness = false
 
+[[example]]
+name = "qubits"
+
 # Optimise dependencies in release mode
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ name = "qubits"
 name = "circuits"
 [[example]]
 name = "hamiltonian"
+[[example]]
+name = "heisenberg"
 
 # Optimise dependencies in release mode
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ harness = false
 name = "qubits"
 [[example]]
 name = "circuits"
+[[example]]
+name = "hamiltonian"
 
 # Optimise dependencies in release mode
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ harness = false
 
 [[example]]
 name = "qubits"
+[[example]]
+name = "circuits"
 
 # Optimise dependencies in release mode
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ Or via cargo:
 ```bash
 cargo add quant-iron
 ```
+### Examples
+The code samples shown below exist as rust examples in the [`examples`](./examples) folder in files named
+`{example-name}.rs`, they can be run using: 
+```shell
+cargo run --example {example-name}
+```
+* `cargo run --example qubits`
 
 ### Quickstart
 

--- a/README.md
+++ b/README.md
@@ -75,9 +75,20 @@ cargo add quant-iron
 ### Examples
 The code samples shown below exist as rust examples in the [`examples`](./examples) folder in files named
 `{example-name}.rs`, they can be run using: 
+
 ```shell
 cargo run --example {example-name}
 ```
+
+You can find the list of examples in the project using
+```
+cargo run --example
+error: "--example" takes one argument.
+Available examples:
+    qubits
+```
+
+And then run the one you with using:
 * `cargo run --example qubits`
 
 ### Quickstart

--- a/examples/circuits.rs
+++ b/examples/circuits.rs
@@ -1,0 +1,22 @@
+use quant_iron::{CircuitBuilder, MeasurementBasis, State, Subroutine};
+
+/// Build a quantum circuit with a QFT subroutine and execute it on a state:**
+
+fn main() {
+    // Build a circuit with 3 qubits
+    let circuit = CircuitBuilder::new(3)
+        .h_gate(0)                                                  // Add a Hadamard gate on qubit 0
+        .cnot_gate(0, 1)                                            // Add a CNOT gate with control=0 and target=1
+        .x_gates(vec![1, 2])                                        // Add Pauli-X gates on qubits 1 and 2
+        .add_subroutine(Subroutine::qft(vec![1, 2], 3))             // Add a QFT subroutine on qubits 1 and 2 for the 3 qubit system
+        .measure_gate(MeasurementBasis::Computational, vec![0, 1])  // Measure qubits 0 and 1
+        .build()
+        .expect("Could not build Circuit");                                                   // Build the circuit
+
+    let state = State::new_plus(3).expect("Could not create state");
+    println!("Initial state: {:?}", state);            // Print the new state after execution
+
+    let new_state = circuit.execute(&state)
+        .expect("Could not execute circuit");        // Execute the circuit on the |++> state
+    println!("New state: {:?}", new_state);            // Print the new state after execution
+}

--- a/examples/hamiltonian.rs
+++ b/examples/hamiltonian.rs
@@ -1,0 +1,18 @@
+use quant_iron::{Pauli, PauliString, State, SumOp};
+
+/// Define a Hamiltonian and compute its expectation value:**
+fn main() {
+    // Define a Hamiltonian for a 2-qubit system
+    let hamiltonian = SumOp::new(Vec::default())                                                  // 2 X_0 + Y_1 + 0.5 Z_0 X_1
+        .with_term(PauliString::new(2.0.into()).with_op(0, Pauli::X))                        // 2X_0
+        .with_term(PauliString::new(1.0.into()).with_op(1, Pauli::Y))                        // Y_1
+        .with_term(PauliString::new(0.5.into()).with_op(0, Pauli::Z).with_op(1, Pauli::X));  // 0.5Z_0 X_1
+
+    // Initialise a |++> state
+    let state = State::new_plus(2).expect("Could not initialize state");
+    // Compute the expectation value for the given state
+    let expectation_value = hamiltonian.expectation_value(&state)
+        .expect("Could not get expectation value");
+    // Print the expectation value for the Hamiltonian
+    println!("Expectation value: {:?}", expectation_value);
+}

--- a/examples/heisenberg.rs
+++ b/examples/heisenberg.rs
@@ -1,0 +1,24 @@
+use quant_iron::heisenberg::heisenberg_1d;
+use quant_iron::State;
+
+/// Create a Hamiltonian for the 1D Heisenberg model and execute it on a state:**
+fn main() {
+    // Define a Hamiltonian for the 1D Heisenberg model
+    let number_of_spins = 3;
+    let coupling_constant_x = 1.0;
+    let coupling_constant_y = 2.0;
+    let coupling_constant_z = 3.0;
+    let field_strength = 0.5;
+    let magnetic_field = 0.1;
+
+    let hamiltonian = heisenberg_1d(number_of_spins, coupling_constant_x,
+                                    coupling_constant_y, coupling_constant_z, field_strength, magnetic_field)
+        .expect("Could not get heisenberg constant value");
+
+    // Initialise a |+++> state
+    let state = State::new_plus(3).expect("Could not initialize state");
+    // Apply the Hamiltonian to the state
+    let modified_state = hamiltonian.apply(&state).expect("Could not apply hamiltonian");
+    // Print the modified state
+    println!("Modified state: {:?}", modified_state);
+}

--- a/examples/qubits.rs
+++ b/examples/qubits.rs
@@ -1,0 +1,18 @@
+/// Create a new quantum state, apply gates, and measure
+use quant_iron::{ChainableState, MeasurementBasis, State};
+
+fn main() {
+    // Initialise a 2-qubit |++> state
+    let state = State::new_plus(2).expect("Could not create state")
+        .h(0)               // Hadamard on qubit 0
+        .x(1)               // Pauli-X on qubit 1
+        .h_multi(&[0, 1])   // Hadamard on both qubits
+        .cnot(0, 1);         // CNOT with control=0, target=1
+
+    // Measure both qubits 100 times
+    let measurement = state.measure_n(MeasurementBasis::Computational, &[0, 1], 100)
+        .expect("Could not measure computation");
+
+    println!("Measurement results: {:?}", measurement);    // Print the outcomes
+    println!("New state: {:?}", measurement );             // Print the new state after measurement
+}

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -2,7 +2,6 @@ use crate::{
     components::{gate::Gate, measurement::MeasurementBasis, operator::Operator, state::State},
     errors::Error,
     subroutine::Subroutine,
-    compiler::compilable::CompilableCircuit,
 };
 
 use num_complex::Complex;

--- a/src/tests/measurement_tests.rs
+++ b/src/tests/measurement_tests.rs
@@ -1,4 +1,4 @@
-use crate::{errors::Error, components::{measurement::MeasurementResult, measurement::MeasurementBasis, state::{State, ChainableState}}};
+use crate::{errors::Error, components::{measurement::MeasurementResult, measurement::MeasurementBasis, state::{State}}};
 use num_complex::Complex;
 
 #[test]

--- a/src/tests/state_tests.rs
+++ b/src/tests/state_tests.rs
@@ -1,4 +1,4 @@
-use crate::{errors::Error, components::state::{State, ChainableState}};
+use crate::{errors::Error, components::state::{State}};
 use num_complex::Complex;
 
 #[test]

--- a/src/tests/time_evolution_tests.rs
+++ b/src/tests/time_evolution_tests.rs
@@ -7,7 +7,6 @@ use crate::{
         pauli_string::{PauliString, SumOp},
         state::State,
     },
-    errors::Error,
 };
 use num_complex::Complex;
 


### PR DESCRIPTION
## Added:
* An examples folder
* An example in the folder for each of the code examples in `README.md`
* An `[[examples]]` entry in `Cargo.toml` for each of them
* An explanation in `README.md` for finding and running provided examples

## Fixed:
* Unused import warnings
* Updated criterian dependency version

## Pending
Things pending, that I would add in a subsequent PR if you agree:
* In the qubits example, the 100 measurements would be best summarized into a single result, no?
* If you agree I would add a test to each example, checking the result is the expected one. That would be easiest if main() just called a function to get the result, and tests could do the same, reducing duplicate code. This would prevent bit-rot, which as already occurred as your API has changes in the 1.1.0 release breaking that code
* You could make those code samples doc tests, and make sure they build and maybe run them (optional) when running `cargo test`. This would ensure they are valid code when making further changes to the API
* Modifying `rust.yml` workflow so that contributed changes are CI tested in GH Actions for all branches/PRs before they are proposed for merge. 

If you agree, we should create a GH issue for each, and I can self-assign some.